### PR TITLE
Avoid deprecation error in the use of imageio.imread

### DIFF
--- a/animation_demo.py
+++ b/animation_demo.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
 
     opt = parser.parse_args()
 
-    source_image = imageio.imread(opt.source_image_pth)
+    source_image = imageio.v2.imread(opt.source_image_pth)
     reader = imageio.get_reader(opt.driving_video_pth)
     fps = reader.get_meta_data()['fps']
     driving_video = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-imageio==2.5.0
+imageio==2.22.2
 imageio-ffmpeg==0.3.0
 matplotlib==3.0.2
 numpy==1.19.5


### PR DESCRIPTION
As of imageIO 2.16.0 (Feb22) there are now a v2 and v3 namespaces in addition to the top-level namespace. In order to avoid a deprecation warning, the call to imageio.imread has been replaced by imageio.v2.imread.

The version of imageio in requirements.txt has also been changed to the most recent version of the module (2.22.2).