### PR TITLE
Explicitly set align_corners=True in calls to grid_sample

### DIFF
--- a/modules/dense_motion.py
+++ b/modules/dense_motion.py
@@ -76,7 +76,7 @@ class DenseMotionNetwork(nn.Module):
         source_repeat = source_image.unsqueeze(1).unsqueeze(1).repeat(1, self.num_kp + 1, 1, 1, 1, 1)
         source_repeat = source_repeat.view(bs * (self.num_kp + 1), -1, h, w)
         sparse_motions = sparse_motions.view((bs * (self.num_kp + 1), h, w, -1))
-        sparse_deformed = F.grid_sample(source_repeat, sparse_motions)
+        sparse_deformed = F.grid_sample(source_repeat, sparse_motions, align_corners=True)
         sparse_deformed = sparse_deformed.view((bs, self.num_kp + 1, -1, h, w))
         return sparse_deformed
 

--- a/modules/generator.py
+++ b/modules/generator.py
@@ -84,7 +84,7 @@ class OcclusionAwareGenerator(nn.Module):
             deformation = deformation.permute(0, 3, 1, 2)
             deformation = F.interpolate(deformation, size=(h, w), mode='bilinear')
             deformation = deformation.permute(0, 2, 3, 1)
-        return F.grid_sample(inp, deformation)
+        return F.grid_sample(inp, deformation, align_corners=True)
 
     def forward(self, source_image, kp_driving=None, kp_source=None, render_ops=None, 
                       blend_mask=None, driving_image=None, driving_features=None):

--- a/modules/model.py
+++ b/modules/model.py
@@ -90,7 +90,7 @@ class Transform:
         grid = make_coordinate_grid(frame.shape[2:], type=frame.type()).unsqueeze(0)
         grid = grid.view(1, frame.shape[2] * frame.shape[3], 2)
         grid = self.warp_coordinates(grid).view(self.bs, frame.shape[2], frame.shape[3], 2)
-        return F.grid_sample(frame, grid, padding_mode="reflection")
+        return F.grid_sample(frame, grid, padding_mode="reflection", align_corners=True)
 
     def warp_coordinates(self, coordinates):
         theta = self.theta.type(coordinates.type())

--- a/modules/tdmm_estimator.py
+++ b/modules/tdmm_estimator.py
@@ -104,7 +104,7 @@ class TDMMEstimator(nn.Module):
 
     def extract_texture(self, images, transformed_verts, with_eye=True):
         uv_pverts = self.world2uv(transformed_verts)
-        uv_gt = F.grid_sample(images, uv_pverts.permute(0, 2, 3, 1)[:, :, :, :2], mode='bilinear')
+        uv_gt = F.grid_sample(images, uv_pverts.permute(0, 2, 3, 1)[:, :, :, :2], mode='bilinear', align_corners=True)
         if with_eye:
             uv_texture_gt = uv_gt[:, :3, :, :] * self.uv_face_eye_mask
         else:


### PR DESCRIPTION
Without this commit, the following warning is issued:

"UserWarning: Default grid_sample and affine_grid behavior has changed to align_corners=False since 1.3.0. Please specify align_corners=True if the old behavior is desired. See the documentation of grid_sample for details."

Since "align_corners=False" (the default value) is specified twice in the code, I presume that the places where the argument align_corners are not used are meant to have "align_corners=True". I may be wrong, though.