### PR TITLE
Explicitly indicate indexing="ij" in call to torch.meshgrid

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -250,7 +250,8 @@ class AntiAliasInterpolation2d(nn.Module):
             [
                 torch.arange(size, dtype=torch.float32)
                 for size in kernel_size
-                ]
+                ],
+            indexing="ij"
         )
         for size, std, mgrid in zip(kernel_size, sigma, meshgrids):
             mean = (size - 1) / 2


### PR DESCRIPTION
According to the documentation (pytorch version 1.11.0): "torch.meshgrid(*tensors) currently has the same behavior as calling numpy.meshgrid(*arrays, indexing=’ij’). In the future torch.meshgrid will transition to indexing=’xy’ as the default."